### PR TITLE
Change version from 999-SNAPSHOT to 999.0.0-SNAPSHOT

### DIFF
--- a/testsuite/integration-arquillian/servers/adapter-spi/pom.xml
+++ b/testsuite/integration-arquillian/servers/adapter-spi/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integration-arquillian-servers</artifactId>
         <groupId>org.keycloak.testsuite</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
     </parent>
     <modelVersion>4.0.0</modelVersion>
     <packaging>pom</packaging>

--- a/testsuite/integration-arquillian/servers/adapter-spi/undertow-adapter-jakarta/pom.xml
+++ b/testsuite/integration-arquillian/servers/adapter-spi/undertow-adapter-jakarta/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integration-arquillian-servers-adapter-spi</artifactId>
         <groupId>org.keycloak.testsuite</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>

--- a/testsuite/integration-arquillian/servers/adapter-spi/undertow-adapter-spi-jakarta/pom.xml
+++ b/testsuite/integration-arquillian/servers/adapter-spi/undertow-adapter-spi-jakarta/pom.xml
@@ -5,7 +5,7 @@
     <parent>
         <artifactId>integration-arquillian-servers-adapter-spi</artifactId>
         <groupId>org.keycloak.testsuite</groupId>
-        <version>999-SNAPSHOT</version>
+        <version>999.0.0-SNAPSHOT</version>
         <relativePath>../pom.xml</relativePath>
     </parent>
     <modelVersion>4.0.0</modelVersion>


### PR DESCRIPTION
Straightforward fix without the necessity to include to the upstream/quarkus3 directly.